### PR TITLE
fix deck name scraping in scrape_deck_list()

### DIFF
--- a/goldfishscrape.py
+++ b/goldfishscrape.py
@@ -30,7 +30,7 @@ def scrape_deck_list(html_deck):
         sideboard = None
         
     main_soup = BeautifulSoup(mainboard, "lxml")
-    deck_name = main_soup.find("h2").text.strip().replace("\n\nSuggest\xa0a\xa0Better"
+    deck_name = main_soup.find("title").text.strip().replace("\n\nSuggest\xa0a\xa0Better"
                                                      "\xa0Name", "")
     if sideboard is None:
         return deck_name, scrape_cards(main_soup), {"None": 0}


### PR DESCRIPTION
Needed to change this to get it working. 

Before: `scrape_deck_list(requests.get("https://www.mtggoldfish.com/deck/983272#paper").text)` would fail
After: `scrape_deck_list(requests.get("https://www.mtggoldfish.com/deck/983272#paper").text)` succeeds